### PR TITLE
チャット欄が正常に表示されない不具合の対応

### DIFF
--- a/sample/AligneLeft.css
+++ b/sample/AligneLeft.css
@@ -228,6 +228,7 @@ yt-live-chat-restricted-participation-renderer {
   display: none !important;
 }
 
+/* 2023/4/30以降Chat v2.0 Style Generatorでチャット欄が正常に表示されない不具合の対応
 @keyframes anim {
 0% { opacity: 0; transform: translateX(-16px); }
 100% { opacity: 1; transform: none;}
@@ -238,7 +239,7 @@ yt-live-chat-legacy-paid-message-renderer {
   animation: anim 200ms;
   animation-fill-mode: both;
 }
-
+*/
 
 yt-live-chat-viewer-engagement-message-renderer{
   display: none !important;


### PR DESCRIPTION
2023/4/30以降、SpeechBubbleCSSのサンプルだとチャット欄が正常に表示されません。
本家のChat v2.0 Style Generatorも同様の事象が発生しているようで、既に対策済みです。
そのため、Chat v2.0 Style Generator日本語版ページのFAQ及びCSS 2023.04.29版を参考に、SpeechBubbleCSSのサンプルスクリプトも同様に、アニメーション関連をコメントアウトしています。 
ご確認頂き、修正が正しいようであれば、必要に応じ他サンプルも修正頂ければと思います。
http://css4obs.starfree.jp/